### PR TITLE
Normalize colors per row.

### DIFF
--- a/cf_matrix.py
+++ b/cf_matrix.py
@@ -101,7 +101,7 @@ def make_confusion_matrix(cf,
 
     # MAKE THE HEATMAP VISUALIZATION
     plt.figure(figsize=figsize)
-    sns.heatmap(cf,annot=box_labels,fmt="",cmap=cmap,cbar=cbar,xticklabels=categories,yticklabels=categories)
+    sns.heatmap(cf / cf.sum(axis=1)[:, np.newaxis],annot=box_labels,fmt="",cmap=cmap,cbar=cbar,xticklabels=categories,yticklabels=categories)
 
     if xyplotlabels:
         plt.ylabel('True label')


### PR DESCRIPTION
Not normalizing the heatmap colors per row makes the confusion matrix seem terrible when classes are imbalanced. Potentially the percentages should also be normalized per row but that is more of a preference.

Before:
<img width="337" alt="Screen Shot 2020-11-09 at 19 02 28" src="https://user-images.githubusercontent.com/104157/98578853-25e7a200-22be-11eb-889c-bbbdc091c951.png">
After:
<img width="339" alt="Screen Shot 2020-11-09 at 19 02 04" src="https://user-images.githubusercontent.com/104157/98578788-12d4d200-22be-11eb-8fe5-2a8e42432bc2.png">


